### PR TITLE
fix: build issues

### DIFF
--- a/Resonite~/ResoniteHook/Puppeteer/Puppeteer.csproj
+++ b/Resonite~/ResoniteHook/Puppeteer/Puppeteer.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <PropertyGroup Label="License">
         <IsDeploymentTarget>true</IsDeploymentTarget>


### PR DESCRIPTION
Puppeteer needs to be an EXE in order for dependencies to be copied.
