### PR TITLE
fix: multiply by alpha, because XiexeToon shader is ignore emission alpha.

### DIFF
--- a/Runtime/Shaders/BakeEmissionMask.shader
+++ b/Runtime/Shaders/BakeEmissionMask.shader
@@ -52,8 +52,11 @@ Shader "Hidden/NDMF/BakeEmission"
             fixed4 frag (v2f i) : SV_Target
             {
                 // sample the texture
-                fixed4 col = tex2D(_EmissionMap, i.uv) * tex2D(_EmissionBlendMask, i.uv_mask);
-                return col;
+                fixed4 maskCol = tex2D(_EmissionMap, i.uv);
+                fixed4 blendMask = tex2D(_EmissionBlendMask, i.uv_mask);
+                maskCol.rgb *= blendMask.rgb;
+                maskCol.rgb *= blendMask.aaa;
+                return maskCol;
             }
             ENDCG
         }


### PR DESCRIPTION
[ctx](https://misskey.niri.la/notes/a7uftihcvs)
[ctx2](https://misskey.niri.la/notes/a7ugexq78k)

XiexeToon はエミッションのアルファを完全に無視するようなので アルファ RGB に乗算することで解決する PR です！