### PR TITLE
feat: implement VisibleHeadAccessory

### DIFF
--- a/Editor/ResoniteBuildPlugin.cs
+++ b/Editor/ResoniteBuildPlugin.cs
@@ -1,0 +1,42 @@
+﻿using nadena.dev.modular_avatar.core;
+using nadena.dev.modular_avatar.resonite;
+using nadena.dev.modular_avatar.resonite.runtime;
+using nadena.dev.ndmf;
+using nadena.dev.ndmf.animator;
+
+[assembly: ExportsPlugin(typeof(ResoniteBuildPlugin))]
+
+namespace nadena.dev.modular_avatar.resonite
+{
+    [RunsOnPlatforms(WellKnownPlatforms.Resonite)]
+    class ResoniteBuildPlugin : Plugin<ResoniteBuildPlugin>
+    {
+        public override string DisplayName => "Modular Avatar - Resonite Build Support";
+
+        protected override void Configure()
+        {
+            InPhase(BuildPhase.Transforming).WithCompatibleExtensions(new []{
+                typeof(AnimatorServicesContext)
+            }, seq =>
+            {
+                seq.BeforePlugin("nadena.dev.modular-avatar")
+                    .Run(RecordVisibleHeadAccessoryPass.Instance);
+            });
+        }
+    }
+    
+    class RecordVisibleHeadAccessoryPass : Pass<RecordVisibleHeadAccessoryPass>
+    {
+        public override string QualifiedName => "nadena.dev.modular-avatar.RecordVisibleHeadAccessoryPass";
+        public override string DisplayName => "Record Visible Head Accessory components for Resonite";
+        
+        protected override void Execute(BuildContext context)
+        {
+            foreach (var vha in context.AvatarRootTransform
+                         .GetComponentsInChildren<ModularAvatarVisibleHeadAccessory>(true))
+            {
+                vha.gameObject.AddComponent<TagVisibleInFirstPerson>();
+            }
+        }
+    }
+}

--- a/Editor/ResoniteBuildPlugin.cs.meta
+++ b/Editor/ResoniteBuildPlugin.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b0f16381a47d4194952bb639c7ebde10
+timeCreated: 1747616842

--- a/Editor/nadena.dev.modular-avatar.resonite.editor.asmdef
+++ b/Editor/nadena.dev.modular-avatar.resonite.editor.asmdef
@@ -7,7 +7,8 @@
         "nadena.dev.modular-avatar.core",
         "nadena.dev.modular-avatar.core.editor",
         "nadena.dev.ndmf.multiplatform.runtime",
-        "lilToon.Editor"
+        "lilToon.Editor",
+        "nadena.dev.modular-avatar.resonite"
     ],
     "includePlatforms": [
         "Editor"

--- a/Resonite~/ResoniteHook/Launcher/Launcher.cs
+++ b/Resonite~/ResoniteHook/Launcher/Launcher.cs
@@ -81,7 +81,7 @@ public class Launcher
         catch (Exception e)
         {
             var path = Assembly.GetExecutingAssembly().Location;
-            path = Path.Combine(Path.GetDirectoryName(path)!, "../../Puppeteer/bin/Debug/net9.0", "Puppeteer.dll");
+            path = Path.Combine(Path.GetDirectoryName(path)!, "../../Puppeteer/bin", "Puppeteer.dll");
 
             puppeteerAssembly = Assembly.LoadFile(path);
         }

--- a/Resonite~/ResoniteHook/Puppeteer/CloudSpawnAssets.cs
+++ b/Resonite~/ResoniteHook/Puppeteer/CloudSpawnAssets.cs
@@ -2,6 +2,6 @@
 
 public static class CloudSpawnAssets
 {
-    public const string CoreSystems = "resrec:///U-1Nj73SRfaDY/R-bd749fb1-2e9d-481c-b6d2-4bf76da071dd";
+    public const string CoreSystems = "resrec:///U-1Nj73SRfaDY/R-b7252d09-1cba-4e59-9026-066091e8fe10";
     public const string LoadingDisplay = "resrec:///U-1Nj73SRfaDY/R-b894b868-2fe3-4494-9cdd-03990fcc4461";
 }

--- a/Resonite~/ResoniteHook/Puppeteer/ResoNamespaces.cs
+++ b/Resonite~/ResoniteHook/Puppeteer/ResoNamespaces.cs
@@ -19,6 +19,8 @@ public class ResoNamespaces
     public const string XSToonTemplate = ModularAvatarNamespacePrefix + "xs_toon_template.";
 
     public const string LoadingGate_NotLoaded = ModularAvatarNamespacePrefix + "MeshNotLoaded";
+    public const string AvatarWorn = ModularAvatarNamespacePrefix + "AvatarWorn";
+    public const string AvatarWornLocal = ModularAvatarNamespacePrefix + "AvatarWornLocal";
 
     public const string AvatarPoseNodePrefix = ModularAvatarNamespacePrefix + "AvatarPoseNode.";
 }

--- a/Resonite~/ResoniteHook/Puppeteer/conversion/AvatarSetup.cs
+++ b/Resonite~/ResoniteHook/Puppeteer/conversion/AvatarSetup.cs
@@ -113,6 +113,8 @@ public partial class RootConverter
     {
         await SetupRig(slot, spec);
         
+        Console.WriteLine("=== TEST ===");
+        
         Defer(PHASE_AVATAR_SETUP, () => SetupAvatarDeferred(slot, spec));
         Defer(PHASE_POSTPROCESS, () => new MeshLoadingFilter(_context).Apply());
         Defer(PHASE_POSTPROCESS, () => new EyeSwingVariableFilter(_context).Apply());
@@ -121,6 +123,7 @@ public partial class RootConverter
         Defer(PHASE_POSTPROCESS, () => new RenderSettingsFilter(_context).Apply());
         Defer(PHASE_POSTPROCESS, () => new AvatarPoseNodeRefFilter(_context).Apply());
         Defer(PHASE_POSTPROCESS, () => new MiscRefFilter(_context).Apply());
+        Defer(PHASE_POSTPROCESS, () => new FirstPersonVisibleFilter(_context).Apply());
         Defer(PHASE_RESOLVE_REFERENCES, () => new BoneAnnotationsFilter(_context).Apply(spec));
 
         return null;

--- a/Resonite~/ResoniteHook/Puppeteer/conversion/RootConverter.cs
+++ b/Resonite~/ResoniteHook/Puppeteer/conversion/RootConverter.cs
@@ -87,6 +87,7 @@ public partial class RootConverter : IDisposable
         _context.Root = _context.AssetRoot;
         _context.SettingsNode = CreateSettingsNode();
         
+        _context.BuildComponentIndex(exportRoot.Root);
         _context.Root = await ConvertGameObject(exportRoot.Root, _world.RootSlot);
 
         _assetRoot.SetParent(_root);

--- a/Resonite~/ResoniteHook/Puppeteer/filters/FirstPersonVisibleFilter.cs
+++ b/Resonite~/ResoniteHook/Puppeteer/filters/FirstPersonVisibleFilter.cs
@@ -1,0 +1,148 @@
+﻿using System.Diagnostics;
+using Elements.Core;
+using FrooxEngine;
+using nadena.dev.resonity.remote.puppeteer.logging;
+using nadena.dev.resonity.remote.puppeteer.rpc;
+
+namespace nadena.dev.resonity.remote.puppeteer.filters;
+
+using F = FrooxEngine;
+using PR = Google.Protobuf.Reflection;
+using P = nadena.dev.ndmf.proto;
+using PM = nadena.dev.ndmf.proto.mesh;
+
+internal partial class FirstPersonVisibleFilter(TranslateContext ctx)
+{
+    Dictionary<F.Slot, bool> IsVisibleInFirstPerson = new();
+    private Dictionary<F.IWorldElement, int> meshSlotReferences = new();
+    private F.IAssetProvider<F.Material>? invisibleMaterial;
+    
+    public async Task Apply()
+    {
+        ResolveVisibility();
+
+        foreach (var mr in ctx.Root!.GetComponentsInChildren<F.MeshRenderer>())
+        {
+            var mesh = mr.Mesh.Target;
+            if (mesh == null) continue;
+            meshSlotReferences[mesh] = meshSlotReferences.GetValueOrDefault(mesh) + 1;
+        }
+
+        List<Task> tasks = new();
+        foreach (var smr in ctx.Root.GetComponentsInChildren<F.SkinnedMeshRenderer>())
+        {
+            var task = ProcessRenderer(smr);
+            await task; // for debugging
+            tasks.Add(task);
+        }
+
+        await Task.WhenAll(tasks);
+    }
+
+    private async Task<F.IAssetProvider<F.Material>> GetInvisibleMaterial()
+    {
+        await new F.ToWorld();
+        if (invisibleMaterial != null) return invisibleMaterial;
+        
+        var slot = ctx.AssetRoot!.AddSlot("Invisible Material");
+        var mat = slot.AttachComponent<F.OverlayUnlitMaterial>();
+        mat.BlendMode.Value = F.BlendMode.Cutout;
+        mat.AlphaCutoff.Value = 1;
+        mat.TintColor = colorX.Clear;
+
+        return invisibleMaterial = mat;
+    }
+
+    private void ResolveVisibility()
+    {
+        if (!ctx.ProtoComponents.TryGetValue(P.VisibleInFirstPerson.Descriptor.FullName, out var componentList))
+        {
+            componentList = new();
+        }
+        
+        foreach ((var slotId, var component) in componentList)
+        {
+            var visibleComponent = component.Component_.Unpack<P.VisibleInFirstPerson>();
+            var slot = ctx.Object<F.Slot>(slotId);
+
+            if (slot != null)
+            {
+                IsVisibleInFirstPerson[slot] = visibleComponent.Visible;
+            }
+        }
+
+        if (!IsVisibleInFirstPerson.ContainsKey(ctx.Root!)) IsVisibleInFirstPerson[ctx.Root!] = true;
+        
+        ResolveVisibility(ctx.Root!);
+    }
+
+    private void ResolveVisibility(F.Slot slot)
+    {
+        if (!IsVisibleInFirstPerson.ContainsKey(slot))
+        {
+            IsVisibleInFirstPerson[slot] = IsVisibleInFirstPerson[slot.Parent];
+        }
+
+        foreach (var child in slot.Children)
+        {
+            ResolveVisibility(child);
+        }
+    }
+
+    private async Task ProcessRenderer(F.SkinnedMeshRenderer smr)
+    {
+        await new F.ToWorld();
+        
+        // Skip broken renderers
+        if (smr.Mesh.Target == null) return;
+        
+        // Skip fully visible renderers
+        if (smr.Bones.All(b => b == null || !IsVisibleInFirstPerson.TryGetValue(b, out var visible) || visible))
+        {
+            return;
+        }
+        
+        // If this mesh is shared, duplicate it first.
+        if (meshSlotReferences[smr.Mesh.Target] > 1)
+        {
+            var meshSlot = (smr.Mesh.Target as F.IComponent).Slot; 
+            meshSlot = meshSlot.Duplicate();
+            smr.Mesh.Target = meshSlot.GetComponent<F.IAssetProvider<F.Mesh>>();
+        }
+
+        var boneToVisible =
+            smr.Bones.Select(bone =>
+                bone == null || (IsVisibleInFirstPerson.TryGetValue(bone, out var visible) && visible)
+            ).ToList();
+
+        var results = await ProcessFPVMesh((F.StaticMesh)smr.Mesh.Target, boneToVisible);
+
+        int firstNewIndex = smr.Materials.Count;
+        foreach (var oldIndex in results.CloneToOriginalIndex)
+        {
+            var newMatEntry = smr.Materials.Add();
+            newMatEntry.DriveFrom(smr.Materials.GetElement(oldIndex));
+        }
+
+        var rmo = smr.Slot.AttachComponent<F.RenderMaterialOverride>();
+        rmo.Renderer.Target = smr;
+        rmo.Context.Value = RenderingContext.UserView;
+        for (int i = firstNewIndex; i < smr.Materials.Count; i++)
+        {
+            var mo = rmo.Overrides.Add();
+            mo.Index.Value = i;
+            mo.Material.Target = await GetInvisibleMaterial();
+        }
+        
+        foreach (var alwaysInvisibleIndex in results.AlwaysInvisibleSubmeshes)
+        {
+            var mo = rmo.Overrides.Add();
+            mo.Index.Value = alwaysInvisibleIndex;
+            mo.Material.Target = await GetInvisibleMaterial();
+        }
+        
+        var avatarWorn = smr.Slot.AttachComponent<F.DynamicValueVariableDriver<bool>>();
+        avatarWorn.VariableName.Value = ResoNamespaces.AvatarWornLocal;
+        avatarWorn.Target.Target = rmo.EnabledField;
+    }
+}

--- a/Resonite~/ResoniteHook/Puppeteer/filters/FirstPersonVisibleMeshProcessor.cs
+++ b/Resonite~/ResoniteHook/Puppeteer/filters/FirstPersonVisibleMeshProcessor.cs
@@ -1,0 +1,152 @@
+﻿using System.Diagnostics;
+using Elements.Assets;
+using FrooxEngine.Store;
+using nadena.dev.resonity.remote.puppeteer.rpc;
+
+namespace nadena.dev.resonity.remote.puppeteer.filters;
+
+using F = FrooxEngine;
+using PR = Google.Protobuf.Reflection;
+using P = nadena.dev.ndmf.proto;
+using PM = nadena.dev.ndmf.proto.mesh;
+
+internal partial class FirstPersonVisibleFilter
+{
+    private const float EPSILON = 0.01f;
+    
+    struct MeshProcessingResults
+    {
+        public List<int> AlwaysInvisibleSubmeshes;
+        public List<int> CloneToOriginalIndex;
+    }
+    
+    private async Task<MeshProcessingResults> ProcessFPVMesh(F.StaticMesh mesh, List<bool> boneToVisible)
+    {
+        var meshName = mesh.Slot.Name;
+        
+        var results = new MeshProcessingResults
+        {
+            AlwaysInvisibleSubmeshes = new List<int>(),
+            CloneToOriginalIndex = new List<int>()
+        };
+        
+        // Await mesh loading
+        Stopwatch timer = new();
+        timer.Start();
+        while (!mesh.IsAssetAvailable && timer.ElapsedMilliseconds < 5000)
+        {
+            await new F.NextUpdate();
+        }
+
+        if (!mesh.IsAssetAvailable)
+        {
+            throw new Exception("Failed to load MeshX asset for mesh " + mesh.Slot.Name);
+        }
+
+        var asset = mesh.Asset;
+
+        await new F.ToBackground();
+        var meshx = new MeshX(); 
+        meshx.Copy(asset.Data);
+        
+        // determine which submeshes need to be split by looking at which vertices they touch
+        bool[] isVertexInvisible = new bool[meshx.VertexCount];
+
+        for (int i = 0; i < meshx.VertexCount; i++)
+        {
+            var bindings = meshx.RawBoneBindings[i];
+            bool isInvisible = false;
+
+            try
+            {
+                isInvisible = isInvisible || (bindings.boneIndex0 >= 0 && bindings.boneIndex0 < boneToVisible.Count 
+                                                && !boneToVisible[bindings.boneIndex0] && bindings.weight0 > EPSILON);
+                isInvisible = isInvisible || (bindings.boneIndex1 >= 0 && bindings.boneIndex1 < boneToVisible.Count
+                                                && !boneToVisible[bindings.boneIndex1] && bindings.weight1 > EPSILON);
+                isInvisible = isInvisible || (bindings.boneIndex2 >= 0 && bindings.boneIndex2 < boneToVisible.Count
+                                                && !boneToVisible[bindings.boneIndex2] && bindings.weight2 > EPSILON);
+                isInvisible = isInvisible || (bindings.boneIndex3 >= 0 && bindings.boneIndex3 < boneToVisible.Count
+                                                && !boneToVisible[bindings.boneIndex3] && bindings.weight3 > EPSILON);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                // One or more bone bindings were invalid; we'll just assume we want to keep this vertex
+                isInvisible = false;
+            }
+
+            isVertexInvisible[i] = isInvisible;
+        }
+
+        int originalSubmeshCount = meshx.SubmeshCount;
+        for (int submeshIndex = 0; submeshIndex < originalSubmeshCount; submeshIndex++)
+        {
+            var submesh = meshx.GetSubmesh(submeshIndex);
+            var newSubmesh = meshx.AddSubmesh(submesh.Topology);
+            newSubmesh.Append(submesh);
+
+            int indicesPerElement = submesh.IndiciesPerElement;
+            int indiceCount = submesh.IndicieCount;
+            
+            bool hasVisible = false;
+            bool hasInvisible = false;
+
+            int oldWritePointer = 0;
+            int newWritePointer = 0;
+            
+            for (int readPointer = 0; readPointer < indiceCount; readPointer += indicesPerElement)
+            {
+                bool isVisibleElement = true;
+                for (int j = 0; j < indicesPerElement; j++)
+                {
+                    if (isVertexInvisible[submesh.RawIndicies[readPointer + j]])
+                    {
+                        isVisibleElement = false;
+                    }
+                }
+
+                if (isVisibleElement)
+                {
+                    // Keep in old submesh
+                    Array.Copy(submesh.RawIndicies, readPointer, submesh.RawIndicies, oldWritePointer, indicesPerElement);
+                    oldWritePointer += indicesPerElement;
+                }
+                else
+                {
+                    Array.Copy(newSubmesh.RawIndicies, readPointer, newSubmesh.RawIndicies, newWritePointer, indicesPerElement);
+                    newWritePointer += indicesPerElement;
+                }
+            }
+
+            if (newWritePointer == 0)
+            {
+                // All elements are fully visible, we can drop the new submesh
+                meshx.RemoveSubmesh(newSubmesh);
+            }
+            else if (oldWritePointer == 0)
+            {
+                // All elements are fully invisible; we can still drop the new submesh, but mark the submesh as always invisible
+                meshx.RemoveSubmesh(newSubmesh);
+                results.AlwaysInvisibleSubmeshes.Add(submeshIndex);
+            }
+            else
+            {
+                // Trim both submeshes to size
+                submesh.SetCount(oldWritePointer / indicesPerElement);
+                newSubmesh.SetCount(newWritePointer / indicesPerElement);
+                results.CloneToOriginalIndex.Add(submeshIndex);
+            }
+        }
+        
+        // Save meshX and reimport
+        string tempFilePath = ctx.Engine.LocalDB.GetTempFilePath(".mesh");
+        meshx.SaveToFile(tempFilePath);
+
+        Uri uri = await ctx.Engine.LocalDB.ImportLocalAssetAsync(tempFilePath, LocalDB.ImportLocation.Move);
+
+        await new F::ToWorld();
+        
+        mesh.URL.Value = uri;
+
+        return results;
+    }
+}

--- a/Runtime/TagVisibleInFirstPerson.cs
+++ b/Runtime/TagVisibleInFirstPerson.cs
@@ -1,0 +1,11 @@
+﻿using nadena.dev.ndmf;
+using UnityEngine;
+
+namespace nadena.dev.modular_avatar.resonite.runtime
+{
+    [AddComponentMenu("")]
+    internal class TagVisibleInFirstPerson : MonoBehaviour, INDMFEditorOnly
+    {
+        
+    }
+}

--- a/Runtime/TagVisibleInFirstPerson.cs.meta
+++ b/Runtime/TagVisibleInFirstPerson.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c5cd4421fd034dd0b7cf9075fb9aeb6a
+timeCreated: 1747616660

--- a/Runtime/assembly-info.cs
+++ b/Runtime/assembly-info.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("nadena.dev.modular-avatar.resonite.editor")]

--- a/Runtime/assembly-info.cs.meta
+++ b/Runtime/assembly-info.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7283edeae9a644d484aaaa178d2f2f65
+timeCreated: 1747617169

--- a/Runtime/nadena.dev.modular-avatar.resonite.asmdef
+++ b/Runtime/nadena.dev.modular-avatar.resonite.asmdef
@@ -1,3 +1,4 @@
 {
-	"name": "nadena.dev.modular-avatar.resonite"
+	"name": "nadena.dev.modular-avatar.resonite",
+	"references":[ "GUID:fe747755f7b44e048820525b07f9b956" ]
 }


### PR DESCRIPTION
By default, any primitives weightpainted to Head or its children will be invisible in first-person, unless VisibleHeadAccessory is attached. This matches the MA VRChat behavior (though the implementation uses material replacement rather than proxy bones).

Closes: #50
