### PR TITLE
fix: Settings Copier reliability issues

### DIFF
--- a/Resonite~/ResoniteHook/Puppeteer/CloudSpawnAssets.cs
+++ b/Resonite~/ResoniteHook/Puppeteer/CloudSpawnAssets.cs
@@ -2,6 +2,6 @@
 
 public static class CloudSpawnAssets
 {
-    public const string CoreSystems = "resrec:///U-1Nj73SRfaDY/R-b7252d09-1cba-4e59-9026-066091e8fe10";
+    public const string CoreSystems = "resrec:///U-1Nj73SRfaDY/R-1546e43f-4dec-4dcd-906b-12a43edfc169";
     public const string LoadingDisplay = "resrec:///U-1Nj73SRfaDY/R-b894b868-2fe3-4494-9cdd-03990fcc4461";
 }


### PR DESCRIPTION
Thanks to esnya and zozokasu for helping debug issues with the prior
version of settings copier!

This fixes an issue where double binding of driven dynvar fields results
in a destroyed reference being found as the avatar settings root.
