### PR TITLE
fix: maskless emission texture with 0 alpha should not be emissive

### DIFF
--- a/Editor/ShaderSupport/IShaderSupport.cs
+++ b/Editor/ShaderSupport/IShaderSupport.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
+using UnityEngine.Experimental.Rendering;
 using UnityEngine;
 
 using p = nadena.dev.ndmf.proto;
@@ -79,7 +80,7 @@ namespace nadena.dev.ndmf.platform.resonite
 
             importerReference = emissionTex;
             
-            if (emissionMask != null && emissionTex != null)
+            if (emissionTex != null && (emissionMask != null || GraphicsFormatUtility.HasAlphaChannel(emissionTex.graphicsFormat)))
             {
                 var newTex = BakeEmissionMask(mat, (Texture2D) emissionTex, emissionMask);
                 if (newTex != null)
@@ -199,11 +200,6 @@ namespace nadena.dev.ndmf.platform.resonite
         
         private Texture2D BakeEmissionMask(Material material, Texture2D emissionMap, Texture2D? emissionMask)
         {
-            if (emissionMask == null)
-            {
-                return null;
-            }
-            
             var width = emissionMap.width;
             var height = emissionMap.height;
             

--- a/Runtime/Shaders/BakeEmissionMask.shader
+++ b/Runtime/Shaders/BakeEmissionMask.shader
@@ -53,6 +53,8 @@ Shader "Hidden/NDMF/BakeEmission"
             {
                 // sample the texture
                 fixed4 maskCol = tex2D(_EmissionMap, i.uv);
+                maskCol.rgb *= maskCol.aaa;
+                maskCol.a = 1;
                 fixed4 blendMask = tex2D(_EmissionBlendMask, i.uv_mask);
                 maskCol.rgb *= blendMask.rgb;
                 maskCol.rgb *= blendMask.aaa;


### PR DESCRIPTION
Contrary to Liltoon, Resonite XiexeToon appears to ignore emission texture (`_EmissionMap`) alpha, causing white pixels with an alpha of 0 to be emissive.

This commit addresses this by baking a new emission map if the emission texture format supports an alpha channel according to **UnityEngine.Experimental.Rendering**.GraphicsFormatUtility:
- multiply rgb with `_EmissionMap` alpha,
- sets the alpha to 1, making the new emission texture opaque.

As implied by the above, an emission mask (`_EmissionBlendMask`) is no longer a requirement for baking a new emission texture.

Input:

![Unity_062Jhs6QOH](https://github.com/user-attachments/assets/3c076afa-d396-4b19-9b49-90f9120463be)

- Emission texture has white pixels with an alpha of 0.
- No separate emission mask.

Output before:

![Resonite_8pe3KEOgrk](https://github.com/user-attachments/assets/3928e284-f2d6-49e9-9808-f0cdd8126840)

Output after:

![Resonite_4YDsrnTRxh](https://github.com/user-attachments/assets/e4b8e55d-1927-4b12-95f3-0724f22a504e)
