### PR TITLE
fix: copy render queue from unity to resonite

### DIFF
--- a/Editor/ShaderSupport/IShaderSupport.cs
+++ b/Editor/ShaderSupport/IShaderSupport.cs
@@ -194,6 +194,7 @@ namespace nadena.dev.ndmf.platform.resonite
             
             protoMat.BlendMode = blendMode;
             protoMat.CullMode = cullMode;
+            protoMat.UnityRenderQueue = material.renderQueue;
 
             return true;
         }

--- a/Resonite~/ResoniteHook/Puppeteer/conversion/Material.cs
+++ b/Resonite~/ResoniteHook/Puppeteer/conversion/Material.cs
@@ -100,6 +100,11 @@ public partial class RootConverter
         // TODO: matcap
         // TODO occlusion map?
 
+        if (src.HasUnityRenderQueue)
+        {
+            mat.RenderQueue.Value = src.UnityRenderQueue;
+        }
+        
         BindExemplarValues(mat, _xsExemplar);
 
         return mat;

--- a/Resonite~/ResoniteHook/ResoPuppetSchema/proto/asset.proto
+++ b/Resonite~/ResoniteHook/ResoPuppetSchema/proto/asset.proto
@@ -60,8 +60,11 @@ message Material {
   optional Color matcap_color = 13;
   // TODO - should we represent alpha mask textures?
   
-  //uint32 render_queue = 3;
-  
+  // Resonite seems to use the same render queue properties as Unity, including the effects on transparency.
+  // While this isn't as portable as we'd like, there's a lot of Unity-based VR games out there, so it makes sense to
+  // support it as optional.
+  optional int32 unity_render_queue = 14;
+
   // TODO...
 }
 


### PR DESCRIPTION
This fixes transparency on a number of avatars (incl Moe)
