### PR TITLE
fix: when there are more material slots than submeshes, FPVFilter does not process meshes correctly

### DIFF
--- a/Resonite~/ResoniteHook/Puppeteer/filters/FirstPersonVisibleFilter.cs
+++ b/Resonite~/ResoniteHook/Puppeteer/filters/FirstPersonVisibleFilter.cs
@@ -115,7 +115,7 @@ internal partial class FirstPersonVisibleFilter(TranslateContext ctx)
                 bone == null || (IsVisibleInFirstPerson.TryGetValue(bone, out var visible) && visible)
             ).ToList();
 
-        var results = await ProcessFPVMesh((F.StaticMesh)smr.Mesh.Target, boneToVisible);
+        var results = await ProcessFPVMesh((F.StaticMesh)smr.Mesh.Target, boneToVisible, smr.Materials.Count);
 
         int firstNewIndex = smr.Materials.Count;
         foreach (var oldIndex in results.CloneToOriginalIndex)

--- a/Resonite~/ResoniteHook/Puppeteer/filters/FirstPersonVisibleMeshProcessor.cs
+++ b/Resonite~/ResoniteHook/Puppeteer/filters/FirstPersonVisibleMeshProcessor.cs
@@ -46,7 +46,7 @@ internal partial class FirstPersonVisibleFilter
         }
     }
     
-    private async Task<MeshProcessingResults> ProcessFPVMesh(F.StaticMesh mesh, List<bool> boneToVisible)
+    private async Task<MeshProcessingResults> ProcessFPVMesh(F.StaticMesh mesh, List<bool> boneToVisible, int minSubmeshes)
     {
         var meshName = mesh.Slot.Name;
         
@@ -113,6 +113,17 @@ internal partial class FirstPersonVisibleFilter
         }
 
         CheckMeshBoneIndices(meshx);
+        
+        
+        while (meshx.SubmeshCount < minSubmeshes)
+        {
+            // Unity duplicates the last submesh if we try to add more than the original count. Since we'll be adding
+            // new submeshes below, though, we need to make sure we don't rely on this hack. As such, we'll duplicate
+            // the last submesh to fill the gap.
+            var lastSubmesh = meshx.GetSubmesh(meshx.SubmeshCount - 1);
+            var newSubmesh = meshx.AddSubmesh(lastSubmesh.Topology);
+            newSubmesh.Append(lastSubmesh);
+        }
         
         int originalSubmeshCount = meshx.SubmeshCount;
         for (int submeshIndex = 0; submeshIndex < originalSubmeshCount; submeshIndex++)


### PR DESCRIPTION
Closes: #127
