### PR TITLE
fix: Set smoothness to 0 when liltoon reflection is disabled

### DIFF
--- a/Editor/ShaderSupport/LiltoonShaderSupport.cs
+++ b/Editor/ShaderSupport/LiltoonShaderSupport.cs
@@ -51,7 +51,14 @@ namespace nadena.dev.ndmf.platform.resonite
             }
 
             protoMat.Metallic = metallic.floatValue;
-            protoMat.Smoothness = smoothness.floatValue;
+            if (material.GetFloat("_Reflection") == 0)
+            {
+                protoMat.Smoothness = 0;
+            }
+            else
+            {
+                protoMat.Smoothness = smoothness.floatValue;
+            }
             protoMat.Reflectivity = reflectance.floatValue;
             
             // Update culling/etc settings based on liltoon config


### PR DESCRIPTION
## Summary
This pull request resolves issue #181, where the smoothness value from lilToon was incorrectly applied to XiexeToon's glossiness even when reflection was disabled.

## Changes
Modified `LiltoonShaderSupport.cs` to check the value of the `_Reflection` property in the lilToon shader. If it is `0` (disabled), the `Smoothness` of the converted　material (which corresponds to Glossiness in XiexeToon) is now set to `0`. If `_Reflection` is enabled, the behavior remains unchanged, and the `Smoothness` value fromliltoon is used.

This ensures that the material settings in liltoon are correctly reflected in the Resonite build.

## Related Issue

Fixes #181