### PR TITLE
fix: use shared object shipped with resonite.

### DIFF
--- a/Resonite~/ResoniteHook/Launcher/Launcher.cs
+++ b/Resonite~/ResoniteHook/Launcher/Launcher.cs
@@ -42,7 +42,7 @@ public class Launcher
             dllPaths.Add(resoniteBase + "/Runtimes/win-x64/native/");
         } else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            dllPaths.Add(resoniteBase + "/Runtimes/linux-x64/native/");
+            dllPaths.Add(resoniteBase + "/runtimes/linux-x64/native/");
         }
 
         AppDomain.CurrentDomain.AssemblyLoad += (sender, args) =>

--- a/Resonite~/ResoniteHook/MA.EngineInterface/EngineController.cs
+++ b/Resonite~/ResoniteHook/MA.EngineInterface/EngineController.cs
@@ -94,7 +94,7 @@ public class EngineController : IAsyncDisposable
         }
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            AssimpLibrary.Instance.LoadLibrary(null, "./libassimp.so.5");
+              AssimpLibrary.Instance.LoadLibrary(null, ResoniteDirectory + "/libassimp.so");
             return;
         }
     }


### PR DESCRIPTION
Splitting 後、 Linux 環境では動作しなくなってしまっていたのでそれのパッチとなります！

内容は resonite が同梱している `.so` を拾うように、変わってしまっている path を調整したものになり、[MA-Resonite-SharedObjectResolver](https://github.com/ReinaS-64892/MA-Resonite-SharedObjectResolver) は不要になります。