### PR TITLE
fix: forget to set output device to headless

### DIFF
--- a/Resonite~/ResoniteHook/MA.EngineInterface/EngineController.cs
+++ b/Resonite~/ResoniteHook/MA.EngineInterface/EngineController.cs
@@ -55,6 +55,7 @@ public class EngineController : IAsyncDisposable
         options.NeverSaveSettings = true;
         options.VerboseInit = true;
         options.DoNotAutoLoadHome = true;
+        options.OutputDevice =  Renderite.Shared.HeadOutputDevice.Headless;
         _engine = new Engine();
 
         bool shutdownRequested = false;

--- a/Resonite~/ResoniteHook/MA.EngineInterface/MA.EngineInterface.csproj
+++ b/Resonite~/ResoniteHook/MA.EngineInterface/MA.EngineInterface.csproj
@@ -83,6 +83,11 @@
             <Private>false</Private>
             <HintPath>$(ResoniteDir)/SkyFrost.Base.Models.dll</HintPath>
         </Reference>
+        <Reference Include="Renderite.Shared">
+            <PrivateAssets>all</PrivateAssets>
+            <Private>false</Private>
+            <HintPath>$(ResoniteDir)/Renderite.Shared.dll</HintPath>
+        </Reference>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
related https://misskey.niri.la/notes/afyuavqm2j

Resonite の Linux 向けサウンド用のライブラリが DLLImportResolver がすでに割り当てられている場合にエラーになるようで、MA-Reso は確定でそれを踏んでしまいます。
ですが、サウンド機能はヘッドレストして有効化しないほうが正しいと思うので option の OutputDevice を headless にして、サウンド機能を無効化することで回避する PR です！