### PR TITLE
fix: resonite moved the path of assimp.dll and libassimp.so

### DIFF
--- a/Resonite~/ResoniteHook/MA.EngineInterface/EngineController.cs
+++ b/Resonite~/ResoniteHook/MA.EngineInterface/EngineController.cs
@@ -89,12 +89,22 @@ public class EngineController : IAsyncDisposable
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            AssimpLibrary.Instance.LoadLibrary(null, ResoniteDirectory + "/assimp.dll");
+            AssimpLibrary.Instance.LoadLibrary(null, Path.Combine(ResoniteDirectory, "runtimes/win-x64/native/assimp.dll"));
             return;
         }
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-              AssimpLibrary.Instance.LoadLibrary(null, ResoniteDirectory + "/libassimp.so");
+            switch (RuntimeInformation.ProcessArchitecture)
+            {
+                default: throw new Exception(RuntimeInformation.ProcessArchitecture + " is unsupported architecture");
+
+                case Architecture.X64:
+                    AssimpLibrary.Instance.LoadLibrary(null, Path.Combine(ResoniteDirectory, "runtimes/linux-x64/native/libassimp.so"));
+                    break;
+                case Architecture.Arm64:
+                    AssimpLibrary.Instance.LoadLibrary(null, Path.Combine(ResoniteDirectory, "runtimes/linux-arm64/native/libassimp.so"));
+                    break;
+            }
             return;
         }
     }


### PR DESCRIPTION
close #230 

ひとまず、 assimp の native dll の読み込みパスを runtimes/(OS-Arch)/native/(lib)assimp.(dll-so) に書き換えたパッチです。

現状 UnityEditor が動かないので意味は無いとは思いますがついでに Linux かつ arm64 の場合の path も解決できるようにしています。

なお Linux 環境では、[それだけでは動作しない](https://misskey.niri.la/notes/ag7k1z7bqs)ようですが ... 