### PR TITLE
Resonite の Headless ARM support に伴うDLL のロード周辺の改修

### DIFF
--- a/Resonite~/ResoniteHook/Launcher/Launcher.cs
+++ b/Resonite~/ResoniteHook/Launcher/Launcher.cs
@@ -42,7 +42,10 @@ public class Launcher
             dllPaths.Add(resoniteBase + "/Runtimes/win-x64/native/");
         } else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            dllPaths.Add(resoniteBase + "/runtimes/linux-x64/native/");
+            if (RuntimeInformation.ProcessArchitecture == Architecture.X64)
+                dllPaths.Add(resoniteBase + "/runtimes/linux-x64/native/");
+            else if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+                dllPaths.Add(resoniteBase + "/runtimes/linux-arm64/native/");
         }
 
         AppDomain.CurrentDomain.AssemblyLoad += (sender, args) =>

--- a/Resonite~/ResoniteHook/Launcher/Launcher.cs
+++ b/Resonite~/ResoniteHook/Launcher/Launcher.cs
@@ -47,7 +47,11 @@ public class Launcher
 
         AppDomain.CurrentDomain.AssemblyLoad += (sender, args) =>
         {
-            NativeLibrary.SetDllImportResolver(args.LoadedAssembly, DllImportResolver);
+            // どうやらすべてのアセンブリに SetDllImportResolver を行ってしまうと衝突してロードに失敗するようになるが、
+            // SteamAudio.NET に限り、以前と同じように DllImportResolver を割り当てておかないと正常にロードできないようだ。
+            // なので雑に SteamAudio.NET にのみ SetDllImportResolver を実行する必要がある。(Resonite 側のコードで他アセンブリ同様正しく行われるとよいのだけれど ... ) by Reina_Sakiria
+            if (args.LoadedAssembly.FullName?.StartsWith("SteamAudio.NET") ?? false)
+                NativeLibrary.SetDllImportResolver(args.LoadedAssembly, DllImportResolver);
         };
 
         AppDomain.CurrentDomain.AssemblyResolve += OnResolveFailed;

--- a/Resonite~/ResoniteHook/MA.EngineInterface/EngineController.cs
+++ b/Resonite~/ResoniteHook/MA.EngineInterface/EngineController.cs
@@ -40,11 +40,12 @@ public class EngineController : IAsyncDisposable
 
     public async Task Start()
     {
+        // あまり検証していないですが、ここで CurrentDirectory を Resonite のインストールされたディレクトリに書き換えておくことで
+        // Resonite が用意、Set する DllImportResolver が正しく動作するようです。 by Reina_Sakiria
+        Directory.SetCurrentDirectory(ResoniteDirectory);
         InitAssimp();
 
-        Assembly.Load("ProtoFlux.Nodes.FrooxEngine");
-        Assembly.Load("ProtoFluxBindings");
-        
+
         _tickController = new TickController();
         StandaloneSystemInfo info = new StandaloneSystemInfo();
         LaunchOptions options = new LaunchOptions();

--- a/Resonite~/ResoniteHook/MA.EngineInterface/EngineController.cs
+++ b/Resonite~/ResoniteHook/MA.EngineInterface/EngineController.cs
@@ -40,17 +40,13 @@ public class EngineController : IAsyncDisposable
 
     public async Task Start()
     {
-        // あまり検証していないですが、ここで CurrentDirectory を Resonite のインストールされたディレクトリに書き換えておくことで
-        // Resonite が用意、Set する DllImportResolver が正しく動作するようです。 by Reina_Sakiria
-        Directory.SetCurrentDirectory(ResoniteDirectory);
         InitAssimp();
-
 
         _tickController = new TickController();
         StandaloneSystemInfo info = new StandaloneSystemInfo();
         LaunchOptions options = new LaunchOptions();
-        options.DataDirectory = Path.Combine(TempDirectory, "Data");
-        options.CacheDirectory = Path.Combine(TempDirectory, "Cache");
+        options.DataDirectory = Path.GetFullPath(Path.Combine(TempDirectory, "Data"));
+        options.CacheDirectory = Path.GetFullPath(Path.Combine(TempDirectory, "Cache"));
         options.FastCompatibility = true;
         options.NeverSaveDash = true;
         options.NeverSaveSettings = true;
@@ -65,6 +61,10 @@ public class EngineController : IAsyncDisposable
         _engine.OnShutdown += () => _shutdownComplete.TrySetResult();
         _engine.EnvironmentShutdownCallback = () => { };
         _engine.EnvironmentCrashCallback = () => { };
+
+        // あまり検証していないですが、ここで CurrentDirectory を Resonite のインストールされたディレクトリに書き換えておくことで
+        // Resonite が用意、Set する DllImportResolver が正しく動作するようです。 by Reina_Sakiria
+        Directory.SetCurrentDirectory(ResoniteDirectory);
 
         await _engine.Initialize(ResoniteDirectory,false, options, info, new ConsoleEngineInitProgress()).ConfigureAwait(false);
 


### PR DESCRIPTION
close #231, close #228 

注意: この PR は #231 と #228 の内容を含みます！

Resonite 2025.12.11.1385 にて Headless ARM support が入ったのと同時に NativeDLL や アセンブリのロード周辺に大きく変更があったようです。

具体的には、Resonite 自ら SetDllImportResolver を使用し DllImportResolver を割り当て、正しく DLL を読み込むような実装が追加されたように見えます。

そのためこの PR では Resonite が追加する DllImportResolver と衝突しないようにし、それが正しく動作するように CurrentDirectory を書き換えています。

ただ、SteamAudio.NET だけは依然として MA-Reso 側の DllImportResolver が必要なようなので、それだけに対して割り当てを行うように改造しています。
